### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 [![Build Status](https://travis-ci.org/Dalveen84/xccdf.svg?branch=master)](https://travis-ci.org/Dalveen84/xccdf)
 [![Coverage Status](https://coveralls.io/repos/Dalveen84/xccdf/badge.png?branch=master)](https://coveralls.io/r/Dalveen84/xccdf?branch=master)
-[![Downloads](https://pypip.in/download/xccdf/badge.png?period=month)](https://pypi.python.org/pypi/xccdf/)
-[![Latest Version](https://pypip.in/version/xccdf/badge.png)](https://pypi.python.org/pypi/xccdf/)
-[![Wheel Status](https://pypip.in/wheel/xccdf/badge.png)](https://pypi.python.org/pypi/xccdf/)
-[![License](https://pypip.in/license/xccdf/badge.png)](https://pypi.python.org/pypi/xccdf/)
+[![Downloads](https://img.shields.io/pypi/dm/xccdf.svg)](https://pypi.python.org/pypi/xccdf/)
+[![Latest Version](https://img.shields.io/pypi/v/xccdf.svg)](https://pypi.python.org/pypi/xccdf/)
+[![Wheel Status](https://img.shields.io/pypi/wheel/xccdf.svg)](https://pypi.python.org/pypi/xccdf/)
+[![License](https://img.shields.io/pypi/l/xccdf.svg)](https://pypi.python.org/pypi/xccdf/)
 [![Stories in Ready](https://badge.waffle.io/dalveen84/xccdf.png?label=ready&title=Ready)](https://waffle.io/dalveen84/xccdf)
 
 Extensible Configuration Checklist Description Format (XCCDF) Python Library.  


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20xccdf))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `xccdf`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.